### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: Simulation-based Inference with the Python Package sbijax
+type: software
+authors:
+- given-names: Simon
+  family-names: Dirmeier
+- given-names: Antonietta
+  family-names: Mira
+- given-names: Carlo
+  family-names: Albert
+repository-code: https://github.com/dirmeier/sbijax
+license: Apache-2.0


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.